### PR TITLE
Adding PGO measurements and random tinkering

### DIFF
--- a/Benchmark/Benchmark.csproj
+++ b/Benchmark/Benchmark.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+  </ItemGroup>
+</Project>

--- a/Benchmark/BenchmarkConfig.cs
+++ b/Benchmark/BenchmarkConfig.cs
@@ -1,0 +1,23 @@
+﻿using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+
+namespace Benchmark
+{
+    public sealed class BenchmarkConfig : ManualConfig
+    {
+        // mrange: Been writing F# since 2010:ish, still can't
+        //  get the OO parts right sometimes so C# it is
+        public BenchmarkConfig()
+        {
+            // Use .NET 6.0 default mode:
+            AddJob(Job.Default.WithId("STD"));
+
+            // Use Dynamic PGO mode:
+            AddJob(Job.Default.WithId("PGO")
+                .WithEnvironmentVariables(
+                    new EnvironmentVariable("DOTNET_TieredPGO"          , "1"),
+                    new EnvironmentVariable("DOTNET_TC_QuickJitForLoops", "1"),
+                    new EnvironmentVariable("DOTNET_ReadyToRun"         , "0")));
+        }
+    }
+}

--- a/HashSetVsBitSet/HashSetVsBitSet.fsproj
+++ b/HashSetVsBitSet/HashSetVsBitSet.fsproj
@@ -14,4 +14,8 @@
     <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Benchmark\Benchmark.csproj" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
I did some random tinkering. The approach I did seems to save an imul but the problem I think comes mainly from the jitter not inlining the function. That leaves alot of prelude epilogue junk that takes precious cycles.

The checking of bounds also takes a bit of time from my looking at the code as it needs to load the bounds from the this pointer.

Anyway, so not much, if any, improvement but I added PGO to the benchmark which is a new feature in .NET6. It didnt help much for me.

I was thinking of forcing inline using F# keyword but the problem is private members needs to be accessible publicaly then.