### PR TITLE
Some further optimizations on inliingbitset _.Map

### DIFF
--- a/HashSetVsCustomBitSet/Program.fs
+++ b/HashSetVsCustomBitSet/Program.fs
@@ -171,16 +171,16 @@ type InliningBitSetTracker (jobCount, machineCount, operationCount: int) =
         buckets[bucketId] <- bucket &&& ~~~mask
 
     member inline x.Map ([<InlineIfLambda>] f: int<JobId> -> int<MachineId> -> int<OperationId> -> 'Result) =
-        let acc = Stack<'Result> (x.JobCount)
+        let acc = ResizeArray<'Result> (x.JobCount)
         let mutable i = 0
         let machineMulOp = x.MachineCount * x.OperationCount
-        // Source of algorithm: https://lemire.me/blog/2018/02/21/iterating-over-set-bits-quickly/
+        // Source of algorithm: https://lemire.me/blog/2018/02/21/iterating-over-set-bits-quickly/            
         while i < x.Buckets.Length do
             let mutable bitSet = x.Buckets[i]
             
             while bitSet <> 0UL do
                 let r = System.Numerics.BitOperations.TrailingZeroCount bitSet
-                let location = i <<< 6 + r
+                let location = (i <<< 6) + r
                 let jobId =
                     location / machineMulOp
                     |> LanguagePrimitives.Int32WithMeasure<JobId>
@@ -192,7 +192,7 @@ type InliningBitSetTracker (jobCount, machineCount, operationCount: int) =
                     location - jobIdMulMachineMulOp - (int machineId) * x.OperationCount
                     |> LanguagePrimitives.Int32WithMeasure<OperationId>
 
-                acc.Push (f jobId machineId operationId)
+                acc.Add (f jobId machineId operationId)
 
                 bitSet <- bitSet ^^^ (1UL <<< r)
 

--- a/HashSetVsCustomBitSet/Program.fs
+++ b/HashSetVsCustomBitSet/Program.fs
@@ -250,42 +250,42 @@ type Benchmarks () =
         b
 
 
-//    [<Benchmark>]
-//    member _.HashSetAdd () =
-//
-//        for jobId, machineId, operationId in addValues do
-//            let assignment = Assignment.create jobId machineId operationId
-//            hashSet.Add assignment |> ignore
-//
-//
-//    [<Benchmark>]
-//    member _.HashSetRemove () =
-//
-//        for jobId, machineId, operationId in removeValues do
-//            let assignment = Assignment.create jobId machineId operationId
-//            hashSet.Remove assignment |> ignore
+    [<Benchmark>]
+    member _.HashSetAdd () =
+
+        for jobId, machineId, operationId in addValues do
+            let assignment = Assignment.create jobId machineId operationId
+            hashSet.Add assignment |> ignore
 
 
-//    [<Benchmark>]
-//    member _.HashSetMap () =
-//
-//        hashSet
-//        |> Seq.map Assignment.decompose
-//        |> Seq.toArray
+    [<Benchmark>]
+    member _.HashSetRemove () =
 
-//
-//    [<Benchmark>]
-//    member _.BitSetAdd () =
-//
-//        for jobId, machineId, operationId in addValues do
-//            bitSet.Add (jobId, machineId, operationId)
-//
-//
-//    [<Benchmark>]
-//    member _.BitSetRemove () =
-//
-//        for jobId, machineId, operationId in removeValues do
-//            bitSet.Remove (jobId, machineId, operationId)
+        for jobId, machineId, operationId in removeValues do
+            let assignment = Assignment.create jobId machineId operationId
+            hashSet.Remove assignment |> ignore
+
+
+    [<Benchmark>]
+    member _.HashSetMap () =
+
+        hashSet
+        |> Seq.map Assignment.decompose
+        |> Seq.toArray
+
+
+    [<Benchmark>]
+    member _.BitSetAdd () =
+
+        for jobId, machineId, operationId in addValues do
+            bitSet.Add (jobId, machineId, operationId)
+
+
+    [<Benchmark>]
+    member _.BitSetRemove () =
+
+        for jobId, machineId, operationId in removeValues do
+            bitSet.Remove (jobId, machineId, operationId)
 
 
     [<Benchmark>]
@@ -294,18 +294,18 @@ type Benchmarks () =
         bitSet.Map (fun a b c -> struct (a, b, c))
 
 
-//    [<Benchmark>]
-//    member _.InliningBitSetAdd () =
-//
-//        for jobId, machineId, operationId in addValues do
-//            inliningBitSet.Add (jobId, machineId, operationId)
-//
-//
-//    [<Benchmark>]
-//    member _.InliningBitSetRemove () =
-//
-//        for jobId, machineId, operationId in removeValues do
-//            inliningBitSet.Remove (jobId, machineId, operationId)
+    [<Benchmark>]
+    member _.InliningBitSetAdd () =
+
+        for jobId, machineId, operationId in addValues do
+            inliningBitSet.Add (jobId, machineId, operationId)
+
+
+    [<Benchmark>]
+    member _.InliningBitSetRemove () =
+
+        for jobId, machineId, operationId in removeValues do
+            inliningBitSet.Remove (jobId, machineId, operationId)
 
     [<Benchmark>]
     member _.InliningBitSetMap () =

--- a/HashSetVsCustomBitSet/Program.fs
+++ b/HashSetVsCustomBitSet/Program.fs
@@ -171,14 +171,13 @@ type InliningBitSetTracker (jobCount, machineCount, operationCount: int) =
         buckets[bucketId] <- bucket &&& ~~~mask
 
     //        member inline x.Map ([<InlineIfLambda>] f: int<JobId> -> int<MachineId> -> int<OperationId> -> 'Result) =
-    member x.Map ( f: int<JobId> -> int<MachineId> -> int<OperationId> -> 'Result) =
-        let length = buckets.Length
+    member inline x.Map ([<InlineIfLambda>] f: int<JobId> -> int<MachineId> -> int<OperationId> -> 'Result) =
         let acc = Stack<'Result> (x.JobCount)
         let mutable i = 0
        
         // Source of algorithm: https://lemire.me/blog/2018/02/21/iterating-over-set-bits-quickly/
-        while i < length do
-            let mutable bitSet = buckets[i]
+        while i < x.Buckets.Length do
+            let mutable bitSet = x.Buckets[i]
 
             while bitSet <> 0UL do
                 let r = System.Numerics.BitOperations.TrailingZeroCount bitSet
@@ -309,5 +308,9 @@ type Benchmarks () =
         for jobId, machineId, operationId in removeValues do
             inliningBitSet.Remove (jobId, machineId, operationId)
 
+    [<Benchmark>]
+    member _.InliningBitSetMap () =
+
+        inliningBitSet.Map (fun a b c -> struct (a, b, c))
 
 let _ = BenchmarkRunner.Run<Benchmarks>()


### PR DESCRIPTION
This gives the following results for me:
```
|            Method |     Mean |    Error |   StdDev |  Gen 0 |  Gen 1 | Allocated |
|------------------ |---------:|---------:|---------:|-------:|-------:|----------:|
|         BitSetMap | 29.76 us | 0.033 us | 0.027 us | 5.8289 | 0.6714 |     48 KB |
| InliningBitSetMap | 23.40 us | 0.256 us | 0.240 us | 3.8147 | 0.3662 |     31 KB |

// * Hints *
Outliers
  Benchmarks.BitSetMap: Default -> 2 outliers were removed (30.29 us, 30.55 us)

```

Overall, I managed to make it inline using new `InlineIfLambda` as well as extracting some code to vars and switching a stack for a System.Collections.Generic.List (aka ResizeArray)