### PR TITLE
Cheating - Sort all the graphs in parallel

### DIFF
--- a/TopologicalSort/Program.fs
+++ b/TopologicalSort/Program.fs
@@ -298,17 +298,17 @@ module Data =
             
         // Generate the random Graphs we will solve
         let graphs =
-            [for _ in 1 .. graphCount ->
-                [|for sourceIdx in 0 .. nodeCount - 2 do
-                     // We use a weighted distribution for the number of edges
-                     for _ in 1 .. randomEdgeCount[(rng.Next randomEdgeCount.Length)] do
-                         let targetIdx = rng.Next (sourceIdx + 1, nodeCount - 1)
-                         let source = nodes[sourceIdx]
-                         let target = nodes[targetIdx]
-                         Edge.create source target |]
-                |> Array.distinct    
-                |> Graph.create
-            ]
+            [| for _ in 1 .. graphCount ->
+                 [|for sourceIdx in 0 .. nodeCount - 2 do
+                      // We use a weighted distribution for the number of edges
+                      for _ in 1 .. randomEdgeCount[(rng.Next randomEdgeCount.Length)] do
+                          let targetIdx = rng.Next (sourceIdx + 1, nodeCount - 1)
+                          let source = nodes[sourceIdx]
+                          let target = nodes[targetIdx]
+                          Edge.create source target |]
+                 |> Array.distinct    
+                 |> Graph.create
+            |]
             
     
 [<MemoryDiagnoser>]
@@ -319,7 +319,7 @@ module Data =
 // [<DisassemblyDiagnoser>]
 type Benchmarks () =
     
-    [<Benchmark>]
+//    [<Benchmark>]
     member _.V01 () =
         let mutable result = None
         
@@ -330,7 +330,7 @@ type Benchmarks () =
 
         result        
         
-    [<Benchmark>]
+//    [<Benchmark>]
     member _.V02 () =
         let mutable result = None
         
@@ -341,7 +341,7 @@ type Benchmarks () =
 
         result  
         
-    [<Benchmark>]
+//    [<Benchmark>]
     member _.V03 () =
         let mutable result = None
         
@@ -418,7 +418,7 @@ type Benchmarks () =
 
         result
         
-    // [<Benchmark>]
+    [<Benchmark>]
     member _.V10 () =
         let mutable result = None
         
@@ -428,16 +428,12 @@ type Benchmarks () =
             result <- sortedOrder
 
         result
-    // [<Benchmark>]
+    [<Benchmark>]
     member _.V11 () =
         let mutable result = ValueNone
-        
-        for graph in Data.Version11.graphs do
-            // I separate the assignment so I can set a breakpoint in debugging
-            let sortedOrder = Version11.Graph.GraphType.Sort &graph
-            result <- sortedOrder
-
-        result 
+        for res in Version11.Graph.GraphType.SortMultiple Data.Version11.graphs do
+            result <- res
+        result
 
 let profile (version: string) loopCount =
     

--- a/TopologicalSort/Version11.fs
+++ b/TopologicalSort/Version11.fs
@@ -4,6 +4,7 @@ open System
 open System.Collections.Generic
 open System.Numerics
 open System.Runtime.InteropServices
+open System.Threading.Tasks
 open Row
 
 [<RequireQualifiedAccess>]
@@ -196,7 +197,12 @@ module Graph =
                 count <- count + (BitOperations.PopCount tracker[i])
             count
             
-            
+        static member SortMultiple(graphs: Graph[]) =
+            let inputLength = graphs.Length
+            let result = GC.AllocateUninitializedArray inputLength
+            Parallel.For(0, inputLength, fun i ->
+                result.[i] <- GraphType.Sort &graphs[i]) |> ignore
+            result
         static member Sort(graph: inref<Graph>) =
             let sourceRanges = graph.SourceRanges
             let sourceEdges = graph.SourceEdges


### PR DESCRIPTION
I guess that's kinda unfair, because the whole point was single-thread sorting (as far as I can tell), but after all why not ?
Things like https://github.com/MrGlockenspiel/activate-linux exist

@matthewcrews 
```
BenchmarkDotNet=v0.13.1, OS=macOS Big Sur 11.4 (20F71) [Darwin 20.5.0]
Intel Core i9-9980HK CPU 2.40GHz, 1 CPU, 16 logical and 8 physical cores
.NET SDK=7.0.100-preview.5.22267.11
  [Host]     : .NET 6.0.2 (6.0.222.6406), X64 RyuJIT DEBUG
  DefaultJob : .NET 6.0.2 (6.0.222.6406), X64 RyuJIT


| Method |       Mean |    Error |   StdDev | Allocated |
|------- |-----------:|---------:|---------:|----------:|
|    V10 | 1,004.8 us | 19.83 us | 36.26 us |    235 KB |
|    V11 |   241.3 us | 13.87 us | 40.46 us |    201 KB |

```