### PR TITLE
add FSharp.HashCollections to benchmark

### DIFF
--- a/ArrayVsDictLookup/ArrayVsDictLookup.fsproj
+++ b/ArrayVsDictLookup/ArrayVsDictLookup.fsproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="argu" Version="6.1.1" />
     <PackageReference Include="benchmarkdotnet" Version="0.13.2" />
+    <PackageReference Include="FSharp.HashCollections" Version="0.3.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Added the immutable collection to compare for curiosity. I expected the mutable collections to be faster, but didn't expect to almost match the `dict` collection despite being a proper immutable structure with O(logn) cloning support.

```
// * Summary *

BenchmarkDotNet=v0.13.2, OS=arch 
AMD Ryzen 7 3700X, 1 CPU, 16 logical and 8 physical cores
.NET SDK=6.0.301
  [Host]     : .NET 6.0.6 (6.0.622.26707), X64 RyuJIT AVX2 DEBUG
  DefaultJob : .NET 6.0.6 (6.0.622.26707), X64 RyuJIT AVX2


|                    Method |        Mean |     Error |    StdDev |
|-------------------------- |------------:|----------:|----------:|
|               ArrayLookup |    535.4 ns |   1.87 ns |   1.66 ns |
|          DictionaryLookup |  4,335.2 ns |   8.24 ns |   6.88 ns |
|  ReadOnlyDictionaryLookup |  5,708.0 ns |  29.63 ns |  26.26 ns |
| ImmutableDictionaryLookup | 23,453.7 ns | 450.26 ns | 536.00 ns |
|                DictLookup | 11,077.2 ns |  14.88 ns |  13.92 ns |
|                 MapLookup | 35,390.2 ns |  73.38 ns |  65.05 ns |
|       FSharpHashMapLookup | 12,110.7 ns |  49.32 ns |  46.14 ns |

// * Hints *
Outliers
  Benchmarks.ArrayLookup: Default              -> 1 outlier  was  removed (549.36 ns)
  Benchmarks.DictionaryLookup: Default         -> 2 outliers were removed (4.39 us, 4.40 us)
  Benchmarks.ReadOnlyDictionaryLookup: Default -> 1 outlier  was  removed (5.77 us)
  Benchmarks.MapLookup: Default                -> 1 outlier  was  removed (35.64 us)

// * Legends *
  Mean   : Arithmetic mean of all measurements
  Error  : Half of 99.9% confidence interval
  StdDev : Standard deviation of all measurements
  1 ns   : 1 Nanosecond (0.000000001 sec)

// ***** BenchmarkRunner: End *****
Run time: 00:02:10 (130.16 sec), executed benchmarks: 7

Global total time: 00:02:12 (132.68 sec), executed benchmarks: 7
```